### PR TITLE
Fix tab switching logic in toggle.js using data-target attribute

### DIFF
--- a/WebContent/JS/Toggle.js
+++ b/WebContent/JS/Toggle.js
@@ -7,10 +7,10 @@ $(document).ready(function () {
       $('.tab-section').hide();
       $(target).show();
     });
-    $('input[type=button][[href^="#"]').click(function (e) {
-        e.preventDefault();
-        var target = $(this).attr('href');
-        $('.tab-section').hide();
-        $(target).show();
+    $('input.Quick-Action-Button').click(function () {
+        var target=$(this).data('target');
+    	if(target){
+    		$('.tab-section').hide();
+    		$(target).show();
       });
   });

--- a/WebContent/admin_home.jsp
+++ b/WebContent/admin_home.jsp
@@ -64,7 +64,7 @@
 </div>
 <div id="card">
 <h3>Quick Actions</h3>
-<input type="button" value="Add New Employee">
+<input type="button" value="Add New Employee" class="Quick-Action-Button" data-target="#EmployeeAdd">
 <input type="button" value="Add New Product">
 <input type="button" value="View Sales Report">
 <input type="button" value="Generate Invoice">


### PR DESCRIPTION
Updated tab switching logic in toggle.js to use 'data-target' instead of relying on 'href' within input buttons.

- Replaced jQuery selector for buttons with class-based targeting (`.Quick-Action-Button`)
- Updated event listener to fetch target tab from `data-target` attribute
- Removed invalid or non-standard use of `href` attribute from <input type="button"> elements
- Added `Quick-Action-Button` class to relevant input buttons to enable proper event binding

This resolves the issue where tab sections were not being displayed on button click due to incorrect selector and attribute usage.
